### PR TITLE
Added safety checks for file existence and now unlinks generated gz file if it failed

### DIFF
--- a/lib/gzipme.js
+++ b/lib/gzipme.js
@@ -8,9 +8,14 @@ const OPTS = {
 
 module.exports = function(file, overwrite) {
   var gzip = zlib.createGzip(OPTS);
+  var gzFile = file + '.gz';
+
+  if (!fs.existsSync(file)) {
+    throw new Error("File '" + file + "' doesn't exist");
+  }
+
   try {
     var inputStream = fs.createReadStream(file);
-    var gzFile = file + '.gz';
     var outStream = fs.createWriteStream(gzFile);
     inputStream.pipe(gzip).pipe(outStream);
     if(overwrite) {
@@ -18,6 +23,9 @@ module.exports = function(file, overwrite) {
       fs.renameSync(gzFile, file);
     }
   } catch (e) {
+    if (!overwrite && fs.existsSync(gzFile)) {
+      fs.unlinkSync(gzFile);
+    }
     throw new Error('Invalid file.');
   }
 };


### PR DESCRIPTION
The problem was that when you run the gzipme with erroneous file path, it still generated an empty .gz file. This commit fixes that by first checking the existence of the file we're trying to gzip and exiting early if it doesn't.

However, there's also a chance that the file did exist, but there was other kind of error (like no read access, no space on disk for the output file content, buffering error, etc.), so it might still create the output file. This commit fixes that in the catch of the error by checking if we created the output file (and also that it wasn't meant to overwrite the existing file) and deleting it.
