### PR TITLE
Wait for async stream fixes #5

### DIFF
--- a/lib/gzipme.js
+++ b/lib/gzipme.js
@@ -37,15 +37,22 @@ module.exports = (file, overwrite = false, mode = 'best', done = () => {}) => {
 
     inputStream.pipe(gzip).pipe(outStream);
 
-    if (overwrite) {
-      fs.unlinkSync(filePath);
-      fs.renameSync(gzFilePath, filePath);
-    }
-    if (outStream && typeof done === 'function') {
-      outStream.on('finish', done);
-    } else {
-      done();
-    }
+    outStream
+      .on('error', () => {
+        throw new Error(`Error gzipping file "${filePath}"`)
+      })
+      .on('close', () => {
+        if (overwrite) {
+          fs.unlinkSync(filePath);
+          fs.renameSync(gzFilePath, filePath);
+        }
+        if (outStream && typeof done === 'function') {
+          outStream.on('finish', done);
+        } else {
+          done();
+        }
+      });
+
   } catch (e) {
     if (!overwrite && fs.existsSync(gzFilePath)) {
       fs.unlinkSync(gzFilePath);


### PR DESCRIPTION
Wait for the output stream to be written before trying to access the file with `fs.renameSync`.

Fixes:
* #5 
* naeramarth7/hexo-command-gzip#1